### PR TITLE
support nginx.service systemd_unit if using systemd

### DIFF
--- a/recipes/nginx.rb
+++ b/recipes/nginx.rb
@@ -117,10 +117,10 @@ end
 
 service "nginx" do
   action node[:nginx][:service_action]
-  not_if { File.exist?('/usr/lib/systemd/system/nginx.service') }
+  not_if { ::File.exist?('/usr/lib/systemd/system/nginx.service') }
 end
 
 systemd_unit 'nginx.service' do
   action node[:mysql][:service_action]
-  only_if { File.exist?('/usr/lib/systemd/system/nginx.service') }
+  only_if { ::File.exist?('/usr/lib/systemd/system/nginx.service') }
 end

--- a/recipes/nginx.rb
+++ b/recipes/nginx.rb
@@ -117,4 +117,10 @@ end
 
 service "nginx" do
   action node[:nginx][:service_action]
+  only_if lazy{ File.exist?('/etc/rc.d/init.d/nginx') }
+end
+
+systemd_unit 'nginx.service' do
+  action node[:mysql][:service_action]
+  not_if lazy{ File.exist?('/etc/rc.d/init.d/nginx') }
 end

--- a/recipes/nginx.rb
+++ b/recipes/nginx.rb
@@ -117,10 +117,10 @@ end
 
 service "nginx" do
   action node[:nginx][:service_action]
-  not_if { ::File.exist?('/usr/lib/systemd/system/nginx.service') }
+  not_if { ::File.exist?('/usr/lib/systemd/system/nginx.service.d') }
 end
 
 systemd_unit 'nginx.service' do
   action node[:mysql][:service_action]
-  only_if { ::File.exist?('/usr/lib/systemd/system/nginx.service') }
+  only_if { ::File.exist?('/usr/lib/systemd/system/nginx.service.d') }
 end

--- a/recipes/nginx.rb
+++ b/recipes/nginx.rb
@@ -117,10 +117,10 @@ end
 
 service "nginx" do
   action node[:nginx][:service_action]
-  only_if lazy{ File.exist?('/etc/rc.d/init.d/nginx') }
+  not_if { File.exist?('/usr/lib/systemd/system/nginx.service') }
 end
 
 systemd_unit 'nginx.service' do
   action node[:mysql][:service_action]
-  not_if lazy{ File.exist?('/etc/rc.d/init.d/nginx') }
+  only_if { File.exist?('/usr/lib/systemd/system/nginx.service') }
 end

--- a/recipes/nginx_default.rb
+++ b/recipes/nginx_default.rb
@@ -33,4 +33,10 @@ end
 
 service "nginx" do
   action node[:nginx][:service_action]
+  only_if lazy{ File.exist?('/etc/rc.d/init.d/nginx') }
+end
+
+systemd_unit 'nginx.service' do
+  action node[:mysql][:service_action]
+  not_if lazy{ File.exist?('/etc/rc.d/init.d/nginx') }
 end


### PR DESCRIPTION
`/usr/lib/systemd/system/nginx.service.d`の有無を確認して、 `service[nginx]`か `systemd_unit[nginx.service]` でサービス管理を分岐します。