### PR TITLE
2019.07 bugfix modphp

### DIFF
--- a/attributes/monit.rb
+++ b/attributes/monit.rb
@@ -31,6 +31,7 @@ default[:monit][:settings][:processes] = [
    :user  => node[:nginx][:config][:user],
    :group => node[:nginx][:config][:group],
    :rules => [
+     'if failed port 80 protocol http then restart'
    ]
   },
   {

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -52,12 +52,14 @@ end
 # install mysql
 include_recipe 'amimoto::mysql'
 
-# install webserver and php
+# install nginx
+include_recipe 'amimoto::nginx'
+#include_recipe 'amimoto::nginx_default'
+
+# install php
 if node[:mod_php7][:enabled]
   include_recipe 'amimoto::mod_php7'
 else
-  include_recipe 'amimoto::nginx'
-  # install nginx
   include_recipe 'amimoto::php'
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -52,14 +52,12 @@ end
 # install mysql
 include_recipe 'amimoto::mysql'
 
-# install nginx
-include_recipe 'amimoto::nginx'
-#include_recipe 'amimoto::nginx_default'
-
-# install php
+# install webserver and php
 if node[:mod_php7][:enabled]
   include_recipe 'amimoto::mod_php7'
 else
+  include_recipe 'amimoto::nginx'
+  # install nginx
   include_recipe 'amimoto::php'
 end
 

--- a/recipes/mod_php7.rb
+++ b/recipes/mod_php7.rb
@@ -86,10 +86,20 @@ end
 
 # php-fpm stop, disable
 
-service "httpd" do
+file '/usr/lib/systemd/system/httpd.service.d/php-fpm.conf' do
+  action :delete
+  notifies :reload_or_try_restart, 'systemd_unit[httpd]'
+end
+
+file '/usr/lib/systemd/system/nginx.service.d/php-fpm.conf' do
+  action :delete
+  notifies :reload_or_try_restart, 'systemd_unit[nginx]'
+end
+
+systemd_unit "httpd" do
   action node[:httpd][:service_action]
 end
 
-service "php-fpm" do
-  action node[:phpfpm][:service_action]
+systemd_unit "php-fpm" do
+  action [:stop, :disable]
 end

--- a/recipes/mod_php7.rb
+++ b/recipes/mod_php7.rb
@@ -88,12 +88,16 @@ end
 
 file '/usr/lib/systemd/system/httpd.service.d/php-fpm.conf' do
   action :delete
-  notifies :reload_or_try_restart, 'systemd_unit[httpd]'
+  if node.run_context.resource_collection.map(&:to_s).include?('systemd_unit[httpd]')
+    notifies :reload_or_try_restart, 'systemd_unit[httpd]'
+  end
 end
 
 file '/usr/lib/systemd/system/nginx.service.d/php-fpm.conf' do
   action :delete
-  notifies :reload_or_try_restart, 'systemd_unit[nginx]'
+  if node.run_context.resource_collection.map(&:to_s).include?('systemd_unit[nginx]')
+    notifies :reload_or_try_restart, 'systemd_unit[nginx]'
+  end
 end
 
 systemd_unit "httpd" do

--- a/recipes/nginx.rb
+++ b/recipes/nginx.rb
@@ -1,7 +1,8 @@
 # nginx install
 node[:nginx][:packages].each do | pkg |
-  package pkg do
+  yum_package pkg do
     action [:install, :upgrade]
+    options ['--disablerepo=*', '--enablerepo=amimoto-nginx-mainline']
     notifies :run, 'bash[update-motd]', :delayed
   end
 end


### PR DESCRIPTION
- check port 80 by monit
  - nginxが起動だけしてlistenしない、ということが発生中 (systemdまわりと思います)
  - restartで治るので、とりあえず。。
- amzn-extraのパッケージで、nginx, httpdの起動がphp-fpmにも依存しちゃってるので、消します。