### PR TITLE
monitのnginx設定変更 AMH-2126

### DIFF
--- a/templates/default/monit/nginx.erb
+++ b/templates/default/monit/nginx.erb
@@ -5,7 +5,7 @@ check process <%= @name %>
   matching "<%= @name %>"
 <% end %>
   start program = "<%= @start %>"
-  stop program = "<%= @stop %> || /usr/bin/kill $(/usr/bin/ps aux | /usr/bin/grep 'nginx: master' | /usr/bin/head -n 1 | /usr/bin/awk '{print $2}')"
+  stop program = "<%= @stop %> || /usr/bin/killall nginx"
 <% @rules.each do |rule| %>
   <%= rule %>
 <% end %>


### PR DESCRIPTION
monit で nginx を停止する際、killall nginx を実行するよう修正しました。